### PR TITLE
Config file for edition picker

### DIFF
--- a/src/app/App.js
+++ b/src/app/App.js
@@ -5,8 +5,7 @@ import Footer from './components/Footer'
 import Head from './components/Head'
 import Carousel from './components/Carousel'
 import Events from './components/Events'
-import Speakers from './components/speakers/Speakers'
-import Members from './components/members/Members'
+import EditionPicker from './components/EditionPicker'
 
 class App extends Component {
   componentDidMount () {
@@ -25,9 +24,8 @@ class App extends Component {
         <Header />
         <Carousel />
         <Events />
-        <Speakers />
-        <Members />
         <Link to='/test' />
+        <EditionPicker />
         <Footer />
       </div>
     )

--- a/src/app/components/Companies.js
+++ b/src/app/components/Companies.js
@@ -1,0 +1,13 @@
+import React, { Component } from 'react'
+
+class Companies extends Component {
+  render () {
+    return (
+      <div>
+        <h3> The companies component is rendered</h3>
+      </div>
+    )
+  }
+}
+
+export default Companies

--- a/src/app/components/EditionPicker.js
+++ b/src/app/components/EditionPicker.js
@@ -1,0 +1,35 @@
+import React, { Component } from 'react'
+import { Button } from 'react-bootstrap'
+import config from '../config.json'
+import Speakers from './speakers/Speakers.js'
+import Companies from './Companies.js'
+import Members from './members/Members.js'
+
+class EditionPicker extends Component {
+  constructor () {
+    super()
+    this.state = {
+      edition: 'sinfo24'
+    }
+  }
+
+  shouldChildRender (componentName) {
+    return config[this.state.edition].indexOf(componentName) > -1
+  }
+
+  render () {
+    return (
+      <div className='Edition-picker'>
+        <Button onClick={() => this.setState({edition: 'sinfo21'})}>SINFO 21</Button>
+        <Button onClick={() => this.setState({edition: 'sinfo22'})}>SINFO 22</Button>
+        <Button onClick={() => this.setState({edition: 'sinfo23'})}>SINFO 23</Button>
+        <Button onClick={() => this.setState({edition: 'sinfo24'})}>SINFO 24</Button>
+        {this.shouldChildRender('Speakers') && <Speakers />}
+        {this.shouldChildRender('Companies') && <Companies />}
+        {this.shouldChildRender('Members') && <Members />}
+      </div>
+    )
+  }
+}
+
+export default EditionPicker

--- a/src/app/config.json
+++ b/src/app/config.json
@@ -1,0 +1,21 @@
+{
+	"sinfo20": [
+		"Speakers"
+	],
+	"sinfo21": [
+		"Speakers"
+	],
+	"sinfo22": [
+		"Companies",
+		"Speakers"
+	],
+	"sinfo23": [
+		"Speakers",
+		"Companies"
+	],
+	"sinfo24": [
+		"Speakers",
+		"Companies",
+		"Members"
+	]
+}


### PR DESCRIPTION
This is a first try of an example of the use of a config file (src/app/config.json) to decide which components to show in the new sinfo edition picker. This is related to issue #21.

For the example, I also created dummy *Team*, *Speakers* and *Companies* components.

Explanation:
*EditionPicker* renders a few buttons and the child components. Its state maintains which edition is picked, and this is passed through props to the *Team*, *Speakers* and *Companies* components. These decide whether to render by reading the config file.

If this is not idiomatic within redux or whatever, please show me the ways!

